### PR TITLE
Portability: use "cp -p" instead of "cp -a".

### DIFF
--- a/do-package.mk
+++ b/do-package.mk
@@ -286,7 +286,7 @@ $(eval $(foreach D,$(TEST_SOURCE_DIRS),$(call package_source_dir_targets,$(D),$(
 define run_broker
 	rm -rf $(TEST_TMPDIR)
 	mkdir -p $(foreach D,log plugins $(NODENAME),$(TEST_TMPDIR)/$(D))
-	cp -a $(PACKAGE_DIR)/dist/*.ez $(TEST_TMPDIR)/plugins
+	cp -p $(PACKAGE_DIR)/dist/*.ez $(TEST_TMPDIR)/plugins
 	$(call copy,$(3),$(TEST_TMPDIR)/plugins)
 	rm -f $(TEST_TMPDIR)/plugins/rabbit_common*.ez
 	for plugin in \
@@ -375,7 +375,7 @@ $(APP_DONE): $(EBIN_BEAMS) $(INCLUDE_HRLS) $(APP_FILE) $(CONSTRUCT_APP_PREREQS)
 	mkdir -p $(APP_DIR)/ebin $(APP_DIR)/include
 	@echo [elided] copy beams to ebin
 	@$(call copy,$(EBIN_BEAMS),$(APP_DIR)/ebin)
-	cp -a $(APP_FILE) $(APP_DIR)/ebin/$(APP_NAME).app
+	cp -p $(APP_FILE) $(APP_DIR)/ebin/$(APP_NAME).app
 	$(call copy,$(INCLUDE_HRLS),$(APP_DIR)/include)
 	$(construct_app_commands)
 	touch $$@


### PR DESCRIPTION
The "-a" option isn't available on BSD systems. Usually, it would
be replaced with "-pR", but since we're operating only on regular
files and not directories, I've skipped surplus "-R".

NOTE: You've got my CLA on file.
