### PR TITLE
Community plugins: Add rabbitmq_email and gen_smtp (its dependency)

### DIFF
--- a/release-build/build-community-plugins.py
+++ b/release-build/build-community-plugins.py
@@ -36,6 +36,10 @@ PLUGINS = [
     ('rabbitmq_sharding',                 {'url': 'https://github.com/rabbitmq/rabbitmq-sharding'}),
 
     # Protocols
+    ('gen_smtp',                          {'url': 'https://github.com/gotthardp/rabbitmq-gen-smtp',
+                                           'erlang': 'R16B'}),
+    ('rabbitmq_email',                    {'url': 'https://github.com/gotthardp/rabbitmq-email',
+                                           'erlang': 'R16B'}),
     ('rfc4627_jsonrpc',                   {'url': 'https://github.com/rabbitmq/erlang-rfc4627-wrapper',
                                            'version-add-hash': False}),
     ('rabbitmq_jsonrpc',                  {'url': 'https://github.com/rabbitmq/rabbitmq-jsonrpc'}),


### PR DESCRIPTION
This is part of issue #3.