### PR TITLE
Makefile: New sync_gituser and sync_gitremote targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,7 +124,7 @@ $(REPOS):
 	user_name="$$(git config user.name)"; \
 	user_email="$$(git config user.email)"; \
 	cd $@ && \
-	git remote set-url --push origin $(GIT_CORE_REPOBASE_PUSH)/$@$(GIT_CORE_SUFFIX_FETCH) && \
+	git remote set-url --push origin $(GIT_CORE_REPOBASE_PUSH)/$@$(GIT_CORE_SUFFIX_PUSH) && \
 	if test "$$global_user_name" != "$$user_name"; then git config user.name "$$user_name"; fi && \
 	if test "$$global_user_email" != "$$user_email"; then git config user.email "$$user_email"; fi
 
@@ -135,6 +135,28 @@ checkout: $(REPOS)
 .PHONY: list-repos
 list-repos:
 	@for repo in $(REPOS); do echo $$repo; done
+
+.PHONY: sync-gituser
+sync-gituser:
+	@global_user_name="$$(git config --global user.name)"; \
+	global_user_email="$$(git config --global user.email)"; \
+	user_name="$$(git config user.name)"; \
+	user_email="$$(git config user.email)"; \
+	for repo in $(REPOS); do \
+	cd $$repo && \
+	git config --unset user.name && \
+	git config --unset user.email && \
+	if test "$$global_user_name" != "$$user_name"; then git config user.name "$$user_name"; fi && \
+	if test "$$global_user_email" != "$$user_email"; then git config user.email "$$user_email"; fi && \
+	cd ..; done
+
+.PHONY: sync-gitremote
+sync-gitremote:
+	@for repo in $(REPOS); do \
+	cd $$repo && \
+	git remote set-url --fetch origin $(GIT_CORE_REPOBASE_FETCH)/$$repo$(GIT_CORE_SUFFIX_FETCH) && \
+	git remote set-url --push origin $(GIT_CORE_REPOBASE_PUSH)/$$repo$(GIT_CORE_SUFFIX_PUSH) && \
+	cd ..; done
 
 #----------------------------------
 # Subrepository management
@@ -166,7 +188,7 @@ status: checkout
 	@for repo in . $(REPOS); do \
 		echo "$$repo:"; \
 		cd "$$repo" && git status -s; \
-		cd -; \
+		cd ..; \
 	done
 
 .PHONY: pull


### PR DESCRIPTION
They are used to propagate the user name/email and "origin" remote URLs
from the umbrella to subrepositories.

This is useful if you forgot to set them before running "make checkout".

While here, fix "git remote set-url --push origin" during the initial
checkout (the wrong URL extension was used), and silence the change of
directory in "make status".

Fixes #5.