### PR TITLE
Makefile: Fix "make up_c" with detached HEAD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,8 +181,10 @@ update: pull
 .PHONY: named_update
 named_update: $(foreach DIR,. $(REPOS),$(DIR)+named_update)
 
-$(eval $(call repo_targets,. $(REPOS),named_update,%+pull,\
-	(cd % && git checkout $(BRANCH) && git pull --ff-only)))
+$(eval $(call repo_targets,. $(REPOS),named_update,| %,\
+	(cd % && git fetch -p --all && git checkout $(BRANCH) && \
+	 (test "$$$$(git branch | grep '^*')" = "* (detached from $(BRANCH))" || \
+	 git pull --ff-only))))
 
 .PHONY: tag
 tag: $(foreach DIR,. $(REPOS),$(DIR)+tag)
@@ -200,4 +202,4 @@ $(eval $(call repo_targets,. $(REPOS),push,| %,\
 checkin: $(foreach DIR,. $(REPOS),$(DIR)+checkin)
 
 $(eval $(call repo_targets,. $(REPOS),checkin,| %,\
-	(cd % && (test -z $$$$(git status -s -uno) || git commit -a))))
+	(cd % && (test -z "$$$$(git status -s -uno)" || git commit -a))))


### PR DESCRIPTION
When checking out a tag, a remote branch or a specific commit (ie.
something not being the HEAD of a local branch), Git operates in
detached HEAD. Before, we didn't verify this case and tried to "git pull
--ff-only" which is invalid.

Now, we check if we are in detached HEAD mode and only "git pull" if we
are not.

While here, fix a missing quote in "make checkin".

Fixes #6.