### PR TITLE
New script to check if a branch is merged before a release

### DIFF
--- a/release-build/is-merged.sh
+++ b/release-build/is-merged.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -e
+
+target=$1
+branch=$2
+
+project=$(basename $(git remote -v | head -n1 | awk '{ print $2 }') | sed 's/\.git$//')
+
+if git branch -a | grep -q "$branch"; then
+	if ! (git branch -a --merged "$target" | grep -q "$branch"); then
+		echo "$project: branch $branch NOT merged to $target"
+	fi
+fi


### PR DESCRIPTION
This script is meant to be called with "foreachrepo". Here is an
example:
    ./foreachrepo $PWD/release-build/is-merged.sh stable \
    rabbitmq-public-umbrella#7

This example will verify is the branch "rabbitmq-public-umbrella#7" was
merged to "stable" in the umbrella and all subrepositories, if the
branch exists in those.

Therefore, it's useful if an issue required changes to the broker and
the testsuite, but not to other repositories.

Fixes #7.