### PR TITLE
Makefile: Restore "cd -" in "make status"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -187,8 +187,7 @@ endef
 status: checkout
 	@for repo in . $(REPOS); do \
 		echo "$$repo:"; \
-		cd "$$repo" && git status -s; \
-		cd ..; \
+		cd "$$repo" && git status -s && cd - >/dev/null; \
 	done
 
 .PHONY: pull


### PR DESCRIPTION
And use `>/dev/null` to silence it.

Fixes #13.