### PR TITLE
improve git detached HEAD detection in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -218,8 +218,7 @@ named_update: $(foreach DIR,. $(REPOS),$(DIR)+named_update)
 
 $(eval $(call repo_targets,. $(REPOS),named_update,| %,\
 	(cd % && git fetch -p && git checkout $(BRANCH) && \
-	 (test "$$$$(git branch | grep '^*')" = "* (detached from $(BRANCH))" || \
-	 git pull --ff-only))))
+	(! git symbolic-ref -q HEAD || git pull --ff-only))))
 
 .PHONY: tag
 tag: $(foreach DIR,. $(REPOS),$(DIR)+tag)


### PR DESCRIPTION
The old approach introduced in 95a0417e1a6bfa51361d5549d2b7701a2425e9b0 doesn't work in git 2.4.2 because the git branch output message format changed from what the Makefile was expecting. 

This approach uses the exit status of `git symbolic-ref` instead and should hopefully be more consistent across git versions.