### PR TITLE
Remove eldap-wrapper from the subrepositories list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@
 
 # Sub-repositories.
 /cowboy-wrapper/
-/eldap-wrapper/
 /mochiweb-wrapper/
 /rabbitmq-amqp1.0/
 /rabbitmq-auth-backend-ldap/

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ REPOS:= \
     rabbitmq-dotnet-client \
     rabbitmq-test \
     cowboy-wrapper \
-    eldap-wrapper \
     mochiweb-wrapper \
     rabbitmq-amqp1.0 \
     rabbitmq-auth-backend-ldap \


### PR DESCRIPTION
Now that RabbitMQ requires R16B03-1, we are sure that eldap is provided
by the standard library.

References rabbitmq/rabbitmq-auth-backend-ldap#10.