### PR TITLE
check_xref: Support a more fine-grained whitelist

### DIFF
--- a/check_xref
+++ b/check_xref
@@ -18,6 +18,8 @@
 %% Copyright (c) 2010-2014 GoPivotal, Inc.  All rights reserved.
 %%
 
+-define(XREF_CHECKS, [undefined_function_calls]).
+
 main([PackageDir, TmpDir]) ->
     {ok, _Pid} = xref:start(?MODULE),
     ok = xref:set_default(?MODULE, [{verbose,false}, {warnings,false}]),
@@ -27,30 +29,19 @@ main([PackageDir, TmpDir]) ->
     {ok, _} = xref:add_directory(?MODULE, TmpDir, {recurse, true}),
     {ok, otp} = xref:add_release(?MODULE, code:lib_dir(), {name, otp}),
 
-    ModulesQ =
-        "(" ++ lists:nthtail(
-                 2, lists:flatten(
-                      [io_lib:format(" + \"~s\" : Mod", [atom_to_list(Mod)])
-                       || Mod <- PackageModules])) ++
-        ")",
-
-    %% 'U' is the set of unknown Functions
-    %% '*' is set intersection
-    %% 'range' takes the RHS in all call pairs (From, To)
-    %% 'closure' gives the transitive closure
-    %% 'E' is all edges (i.e. all calls)
-    %% '|' is the subset of calls from any of the vertices
-    %%
-    %% I.e. we construct the transitive closure of all calls from any
-    %% of the plugin's modules, look at the ranges there of
-    %% (i.e. callees, not callers), and see if they're unknown
-    Q = "U * range (closure E | " ++ ModulesQ ++")",
-    {ok, MFAs} = xref:q(?MODULE, Q),
-    case filter_noise(MFAs, PackageModules) of
-        []     -> ok;
-        PrMFAs -> io:format("Undefined functions:~n"),
-                  [io:format("\t~s:~s/~w~n", [M, F, A]) || {M, F, A} <- PrMFAs],
-                  exit(undefined_functions)
+    Ret = lists:foldl(
+      fun(Check, Acc) ->
+          {ok, Result} = xref:analyze(?MODULE, Check, [{verbose, true}]),
+          Filtered = filter_noise(Check, Result),
+          print_result(Check, Filtered) andalso Acc
+      end, true, ?XREF_CHECKS),
+    if
+        Ret ->
+            io:format("xref: OK~n"),
+            halt(0);
+        true ->
+            io:format("~nxref: FAILURE~n"),
+            halt(1)
     end.
 
 add_dir(PackageDir, Dir) ->
@@ -60,18 +51,39 @@ add_dir(PackageDir, Dir) ->
         false -> {ok, []}
     end.
 
-filter_noise(MFAs, Modules) ->
-    [MFA || MFA <- MFAs, is_interesting(MFA, Modules)].
+filter_noise(Check, Result) ->
+    [Item || Item <- Result, is_interesting(Check, Item)].
 
-is_interesting({'$M_EXPR', _, _},  _Ms) -> false;
-is_interesting({_, '$F_EXPR', _},  _Ms) -> false;
-is_interesting({_, _, -1},         _Ms) -> false;
-%% Cowboy invokes file:sendfile/2 which is only on very recent
-%% Erlang. However it is guarded by a call to
-%% erlang:function_exported/3.
-is_interesting({file, sendfile, 2}, Ms) -> not lists:member(cowboy, Ms);
+%% Eunit testsuite for undefined function calls.
+is_interesting(undefined_function_calls,
+  {{eunit_test, wrapper_test_exported_, 0},
+   {eunit_test, nonexisting_function, 0}}) ->
+    false;
+%% ssl_compat calls functions appeared in Erlang 18.0's ssl and falls
+%% back on deprecated functions.
+is_interesting(undefined_function_calls,
+  {{ssl_compat, F, A},
+   {ssl, F, A}}) ->
+    false;
+%% Cowboy invokes file:sendfile/2 which is only on very recent Erlang.
+%% However it is guarded by a call to erlang:function_exported/3.
+is_interesting(undefined_function_calls,
+  {{cowboy_http_static, sendfile, 2},
+   {file, sendfile, 2}}) ->
+    false;
 %% Tests need this function, which technically makes it part of a
 %% plugin. But it's only in newer Erlangs than we test with.
-is_interesting({cover, flush, 1}, Ms)   -> not lists:member(
-                                                 rabbit_test_runner, Ms);
-is_interesting(_,                  _Ms) -> true.
+is_interesting(undefined_function_calls,
+  {{rabbit_test_configs, maybe_flush_cover, 1},
+   {cover, flush, 1}}) ->
+    false;
+is_interesting(_, _) ->
+    true.
+
+print_result(undefined_function_calls, []) ->
+    true;
+print_result(undefined_function_calls, UndefinedFunctionCalls) ->
+    io:format("~nUndefined function call(s):~n"),
+    [io:format("\t~s:~s/~w (in ~s:~s/~w)~n", [M2, F2, A2, M1, F1, A1])
+      || {{M1, F1, A1}, {M2, F2, A2}} <- UndefinedFunctionCalls],
+    false.


### PR DESCRIPTION
This is required to support calling possibly undefined functions in `ssl_compat` and `time_compat`.

Fixes #25.