### PR TITLE
Don't force erlang-src installation in build.sh

### DIFF
--- a/release-build/build.sh
+++ b/release-build/build.sh
@@ -136,7 +136,7 @@ fi
     DEBIAN_FRONTEND=noninteractive ; export DEBIAN_FRONTEND
     apt-get -y update
     apt-get -y dist-upgrade
-    apt-get -y install ncurses-dev rsync cdbs elinks python-simplejson rpm tofrodos zip unzip ant $java_package htmldoc plotutils transfig graphviz docbook-utils texlive-fonts-recommended gs-gpl python2.5 erlang-dev erlang-nox erlang-src python-pexpect openssl s3cmd fakeroot git-core m4 xmlto mercurial xsltproc nsis
+    apt-get -y install ncurses-dev rsync cdbs elinks python-simplejson rpm tofrodos zip unzip ant $java_package htmldoc plotutils transfig graphviz docbook-utils texlive-fonts-recommended gs-gpl python2.5 erlang-dev erlang-nox python-pexpect openssl s3cmd fakeroot git-core m4 xmlto mercurial xsltproc nsis
     [ -n "$uja_command" ] && eval $uja_command
 '
 


### PR DESCRIPTION
It conflicts with ESL Erlang packages (depends on `erlang-base`) used on our Debian release build machine. While it may be required
in some environments, it seems to me that release build infra should be managed by tools
such as Puppet and not strictly enforced here.

Or we could simply upgrade the Debian release environment and avoid such conflicts.