### PR TITLE
Don't create symlink to current Javadoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -557,11 +557,6 @@ deploy:
 			$(DIR)/ \
 			$(DEPLOY_PATH)/$(patsubst $(PACKAGES_DIR)/%,%,$(DIR))/ \
 	)
-	$(verbose) cd $(DEPLOY_PATH)/rabbitmq-java-client; \
-		 rm -f current-javadoc; \
-		 ln -s \
-		  `cd $(abspath $(JAVA_CLIENT_PACKAGES_DIR)/..) && \
-		   ls -td */rabbitmq-java-client-javadoc-*/ | head -1` current-javadoc
 	$(verbose) cd $(DEPLOY_PATH)/rabbitmq-server; \
 		 rm -f current; \
 		 ln -s v$(VERSION) current
@@ -574,12 +569,6 @@ deploy:
 			$(DIR)/ \
 			$(DEPLOY_HOST):$(DEPLOY_PATH)/$(patsubst $(PACKAGES_DIR)/%,%,$(DIR))/ \
 	)
-	$(verbose) ssh $(SSH_OPTS) $(DEPLOY_HOST) \
-		"(cd $(DEPLOY_PATH)/rabbitmq-java-client; \
-		 rm -f current-javadoc; \
-		 ln -s \
-		  `cd $(abspath $(JAVA_CLIENT_PACKAGES_DIR)/..) && \
-		   ls -td */rabbitmq-java-client-javadoc-*/ | head -1` current-javadoc)"
 	$(verbose) ssh $(SSH_OPTS) $(DEPLOY_HOST) \
 		'(cd $(DEPLOY_PATH)/rabbitmq-server; \
 		 rm -f current; \


### PR DESCRIPTION
This PR remove the symlink creation to current Javadoc. When Java Client 4.0 is released, Javadoc will be uploaded to `releases/rabbitmq-java-client/current-javadoc` by the Java Client build.

This PR should be merged just after the release of Java Client 4.0.
