### PR TITLE
Makefile: Manpages are now HTML files, not XML files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ release-unix-server-packages:
 		$(UNIX_SERVER_VARS) \
 		NO_CLEAN=yes
 	$(verbose) $(RSYNC) $(RSYNC_FLAGS) \
-		--include '*.man.xml' \
+		--include '*.html' \
 		--exclude '*' \
 		$(DEPS_DIR)/rabbitmq_server_release/packaging/generic-unix/rabbitmq-server-$(VERSION)/deps/rabbit/docs/ \
 		$(SERVER_PACKAGES_DIR)/man/
@@ -242,7 +242,7 @@ release-unix-server-packages:
 		$(UNIX_HOST):$(REMOTE_RELEASE_TMPDIR)/packaging/PACKAGES/ \
 		$(SERVER_PACKAGES_DIR)/
 	$(verbose) $(RSYNC) $(RSYNC_FLAGS) \
-		--include '*.man.xml' \
+		--include '*.html' \
 		--exclude '*' \
 		$(UNIX_HOST):$(REMOTE_RELEASE_TMPDIR)/packaging/generic-unix/rabbitmq-server-$(VERSION)/deps/rabbit/docs/ \
 		$(SERVER_PACKAGES_DIR)/man/


### PR DESCRIPTION
Therefore, we want to copy `*.html` to the target `man` directory instead of the former `*.man.xml` files.

This depends on rabbitmq-server#1201 which must be merged first.

[#143563295]