### PR TITLE
URL Cleanup

### DIFF
--- a/release-build/deploy.sh
+++ b/release-build/deploy.sh
@@ -19,7 +19,7 @@ KEYSDIR=
 # The base URL of the rabbitmq website where the results of the build
 # will actually be available.  Optional, defaults to the rabbitmq.com
 # site
-REAL_WEB_URL=http://www.rabbitmq.com/
+REAL_WEB_URL=https://www.rabbitmq.com/
 
 # Mac OS X host used to produce OS X-specific artifacts
 MAC_USERHOST=


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.rabbitmq.com/ with 1 occurrences migrated to:  
  https://www.rabbitmq.com/ ([https](https://www.rabbitmq.com/) result 200).