### PR TITLE
URL Cleanup

### DIFF
--- a/rabbitmq-docs/specs/amqp.0-10.xml
+++ b/rabbitmq-docs/specs/amqp.0-10.xml
@@ -98,11 +98,11 @@
 
   Links to full AMQP specification:
   =================================
-  http://www.envoytech.org/spec/amq/
-  http://www.iona.com/opensource/amqp/
-  http://www.redhat.com/solutions/specifications/amqp/
-  http://www.twiststandards.org/tiki-index.php?page=AMQ
-  http://www.imatix.com/amqp
+  https://www.envoytech.org/spec/amq/
+  /YoadZ/opensource/amqp/
+  https://www.redhat.com/solutions/specifications/amqp/
+  http://twiststandards.org/tiki-index.php?page=AMQ
+  https://www.imatix.com/amqp
 -->
 
 <!--
@@ -123,7 +123,7 @@
 
 <!DOCTYPE amqp SYSTEM "amqp.dtd">
 
-<amqp xmlns="http://www.amqp.org/schema/amqp.xsd"
+<amqp xmlns="https://www.amqp.org/schema/amqp.xsd"
     major="0" minor="10" port="5672">
 
   <!--
@@ -888,7 +888,7 @@
 
     <doc>
       1) The list-of-pairs representation is sorted ascending (as defined by RFC 1982
-      (http://www.ietf.org/rfc/rfc1982.txt) ) by the first elements of each pair.
+      (https://www.ietf.org/rfc/rfc1982.txt) ) by the first elements of each pair.
     </doc>
 
     <doc>
@@ -1450,7 +1450,7 @@
         tcp_prot_addr     = tcp_id tcp_addr
         tcp_id            = "tcp:" | ""
         tcp_addr          = [host [":" port] ]
-        host              = <as per http://www.ietf.org/rfc/rfc3986.txt>
+        host              = <as per https://www.ietf.org/rfc/rfc3986.txt>
         port              = number]]>
       </doc>
     </domain>

--- a/rabbitmq-docs/specs/amqp0-8.xml
+++ b/rabbitmq-docs/specs/amqp0-8.xml
@@ -113,11 +113,11 @@ marks of others.
 
 Links to full AMQP specification:
 =================================
-http://www.envoytech.org/spec/amq/
-http://www.iona.com/opensource/amqp/
-http://www.redhat.com/solutions/specifications/amqp/
-http://www.twiststandards.org/tiki-index.php?page=AMQ
-http://www.imatix.com/amqp
+https://www.envoytech.org/spec/amq/
+/YoadZ/opensource/amqp/
+https://www.redhat.com/solutions/specifications/amqp/
+http://twiststandards.org/tiki-index.php?page=AMQ
+https://www.imatix.com/amqp
 
 -->
 

--- a/rabbitmq-docs/specs/amqp0-9-1.xml
+++ b/rabbitmq-docs/specs/amqp0-9-1.xml
@@ -129,7 +129,7 @@
 
     Links to full AMQP specification:
     =================================
-    http://www.amqp.org
+    https://www.amqp.org
 -->
 
 <!--

--- a/rabbitmq-docs/specs/amqp0-9.xml
+++ b/rabbitmq-docs/specs/amqp0-9.xml
@@ -126,11 +126,11 @@
     
     Links to full AMQP specification:
     =================================
-    http://www.envoytech.org/spec/amq/
-    http://www.iona.com/opensource/amqp/
-    http://www.redhat.com/solutions/specifications/amqp/
-    http://www.twiststandards.org/tiki-index.php?page=AMQ
-    http://www.imatix.com/amqp
+    https://www.envoytech.org/spec/amq/
+    /YoadZ/opensource/amqp/
+    https://www.redhat.com/solutions/specifications/amqp/
+    http://twiststandards.org/tiki-index.php?page=AMQ
+    https://www.imatix.com/amqp
 -->
 
 <!--

--- a/rabbitmq-docs/specs/qpid-amqp.0-8.xml
+++ b/rabbitmq-docs/specs/qpid-amqp.0-8.xml
@@ -113,11 +113,11 @@
 	
 	Links to full AMQP specification:
 	=================================
-	http://www.envoytech.org/spec/amq/
-	http://www.iona.com/opensource/amqp/
-	http://www.redhat.com/solutions/specifications/amqp/
-	http://www.twiststandards.org/tiki-index.php?page=AMQ
-	http://www.imatix.com/amqp
+	https://www.envoytech.org/spec/amq/
+	/YoadZ/opensource/amqp/
+	https://www.redhat.com/solutions/specifications/amqp/
+	http://twiststandards.org/tiki-index.php?page=AMQ
+	https://www.imatix.com/amqp
 	
 -->
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* http://www.twiststandards.org/tiki-index.php?page=AMQ (301) with 4 occurrences could not be migrated:  
   ([https](https://www.twiststandards.org/tiki-index.php?page=AMQ) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://www.iona.com/opensource/amqp/ (302) with 4 occurrences migrated to:  
  /YoadZ/opensource/amqp/ ([https](https://www.iona.com/opensource/amqp/) result IllegalArgumentException).
* http://www.envoytech.org/spec/amq/ (UnknownHostException) with 4 occurrences migrated to:  
  https://www.envoytech.org/spec/amq/ ([https](https://www.envoytech.org/spec/amq/) result UnknownHostException).
* http://www.amqp.org/schema/amqp.xsd (404) with 1 occurrences migrated to:  
  https://www.amqp.org/schema/amqp.xsd ([https](https://www.amqp.org/schema/amqp.xsd) result 404).
* http://www.imatix.com/amqp (404) with 4 occurrences migrated to:  
  https://www.imatix.com/amqp ([https](https://www.imatix.com/amqp) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.amqp.org with 1 occurrences migrated to:  
  https://www.amqp.org ([https](https://www.amqp.org) result 200).
* http://www.ietf.org/rfc/rfc1982.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc1982.txt ([https](https://www.ietf.org/rfc/rfc1982.txt) result 200).
* http://www.ietf.org/rfc/rfc3986.txt with 1 occurrences migrated to:  
  https://www.ietf.org/rfc/rfc3986.txt ([https](https://www.ietf.org/rfc/rfc3986.txt) result 200).
* http://www.redhat.com/solutions/specifications/amqp/ with 4 occurrences migrated to:  
  https://www.redhat.com/solutions/specifications/amqp/ ([https](https://www.redhat.com/solutions/specifications/amqp/) result 301).